### PR TITLE
Add requirements.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ config = {
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.7',
     ],
-    'version': '0.0.1',
+    'version': '0.0.2',
     'packages': ['qproxy'],
     'scripts': [],
     'name': 'qproxy',


### PR DESCRIPTION
If we upload the egg to our pypi and then try to install the package, it fails because it can't read the pip requirements file:

`Collecting tornado-dnslib==0.0.1 Downloading https://pypi.infra.wish.com/api/package/tornado-dnslib/tornado_dnslib-0.0.1.tar.gz ERROR: Command errored out with exit status 1: command: /home/vitaliy/mypypi/bin/python2 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-zHa_io/tornado-dnslib/setup.py'"'"'; __file__='"'"'/tmp/pip-install-zHa_io/tornado-dnslib/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info cwd: /tmp/pip-install-zHa_io/tornado-dnslib/ Complete output (7 lines): Traceback (most recent call last): File "<string>", line 1, in <module> File "/tmp/pip-install-zHa_io/tornado-dnslib/setup.py", line 28, in <module> 'install_requires': get_requirements(), File "/tmp/pip-install-zHa_io/tornado-dnslib/setup.py", line 9, in get_requirements with open('requirements.txt') as fp: IOError: [Errno 2] No such file or directory: 'requirements.txt' ---------------------------------------- ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.`

Stack overflow says to include this file in MANIFEST.in to fix it https://stackoverflow.com/questions/26319101/setup-py-doesnt-see-my-requirements-txt